### PR TITLE
Fix handling of app with pm_id=0 in detectActiveApps

### DIFF
--- a/core/pm2.ts
+++ b/core/pm2.ts
@@ -94,7 +94,7 @@ const detectActiveApps = () => {
             // Get the last app instance status
             mapAppPids[appName].status = appInstance.pm2_env?.status;
 
-            if (appInstance.pid && appInstance.pm_id) {
+            if (appInstance.pid && appInstance.pm_id !== undefined) {
                 mapAppPids[appName].pids.push(appInstance.pid);
 
                 // Fill active pm2 apps id to collect internal statistic


### PR DESCRIPTION
## Summary
- fix app instance filtering in `detectActiveApps` to correctly handle `pm_id = 0`
- change condition from truthy check to explicit `undefined` check

## Problem
PM2 can assign `pm_id = 0` to the first process. Current code has:

```ts
if (appInstance.pid && appInstance.pm_id) {
```

For `pm_id = 0`, this condition is false, so the process is skipped from `pidsMonit`/PID metrics collection.

## Fix
Use explicit `undefined` check:

```ts
if (appInstance.pid && appInstance.pm_id !== undefined) {
```

This preserves existing behavior while correctly including process ID `0`.

## Validation
- npm install
- npm run build (TypeScript compile succeeds)
